### PR TITLE
Removes default conda channels from envs

### DIFF
--- a/workflow/envs/metagenomics_db.yaml
+++ b/workflow/envs/metagenomics_db.yaml
@@ -3,7 +3,6 @@ name: metagenomics_db
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - python=3.10
   - biopython

--- a/workflow/envs/pandas_java.yaml
+++ b/workflow/envs/pandas_java.yaml
@@ -2,7 +2,6 @@
 name: pandas
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - pandas
   - openjdk=11.0.1

--- a/workflow/envs/pandas_mono.yaml
+++ b/workflow/envs/pandas_mono.yaml
@@ -2,7 +2,6 @@
 name: pandas
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - mono
   - pandas


### PR DESCRIPTION
This PR ensures that only conda-forge and bioconda channels will be used by conda, when snakemake makes the envs.
This is important for users that cannot use anaconda.org default channels if they do not have appropriate licences, but who may not have set their channel defaults appropriately.